### PR TITLE
Update SqlShell.php

### DIFF
--- a/app/Console/Command/SqlShell.php
+++ b/app/Console/Command/SqlShell.php
@@ -117,7 +117,7 @@ class SqlShell extends AppShell {
 		// Build the dump command.
 		$cmd = 'mysqldump -h ' . $config['host'] . ' -u ' . $config['login'];
 		if (!empty($config['password'])) {
-			$cmd .= ' -p' . $config['password'];
+			$cmd .= ' -p"' . $config['password'] . '"';
 		}
 		$cmd .= ' ' . $config['database'] . ' > ' . $this->file;
 


### PR DESCRIPTION
Solve #72: when the password of the database account contain a shell interpreted character, the command fail