### PR TITLE
Expose the 'client' variable in default conf.

### DIFF
--- a/app/Config/email.php.default
+++ b/app/Config/email.php.default
@@ -44,6 +44,7 @@ class EmailConfig {
 		'timeout' => 30,
 		'username' => '',
 		'password' => '',
+		'client' => null,
 		'tls' => false,
 	);
 


### PR DESCRIPTION
The 'client' setting control what the Smtp client sends as EHLO/HELO
message to the smtp-server. If left to the default null-value, it will
default to either HTTP_HOST or localhost, as per line 151 and onwards in
lib/Cake/Network/Email/SmtpTransport.php

This can later be added into passbolt_docker to make it configureable
via environment variables.