### PR TITLE
Use CONFIG instead of "ROOT . DS . 'config'"

### DIFF
--- a/config/default.php
+++ b/config/default.php
@@ -117,8 +117,8 @@ return [
             'serverKey' => [
                 // Server public / private key location and fingerprint.
                 'fingerprint' => env('PASSBOLT_GPG_SERVER_KEY_FINGERPRINT', null),
-                'public' => env('PASSBOLT_GPG_SERVER_KEY_PUBLIC', ROOT . DS . 'config' . DS . 'gpg' . DS . 'serverkey.asc'),
-                'private' => env('PASSBOLT_GPG_SERVER_KEY_PRIVATE', ROOT . DS . 'config' . DS . 'gpg' . DS . 'serverkey_private.asc'),
+                'public' => env('PASSBOLT_GPG_SERVER_KEY_PUBLIC', CONFIG . DS . 'gpg' . DS . 'serverkey.asc'),
+                'private' => env('PASSBOLT_GPG_SERVER_KEY_PRIVATE', CONFIG . DS . 'gpg' . DS . 'serverkey_private.asc'),
 
                 // PHP Gnupg module currently does not support passphrase, please leave blank.
                 'passphrase' => ''

--- a/config/passbolt.default.php
+++ b/config/passbolt.default.php
@@ -100,8 +100,8 @@ return [
             'serverKey' => [
                 // Server private key fingerprint.
                 'fingerprint' => '',
-                //'public' => ROOT . DS . 'config' . DS . 'gpg' . DS . 'serverkey.asc',
-                //'private' => ROOT . DS . 'config' . DS . 'gpg' . DS . 'serverkey_private.asc',
+                //'public' => CONFIG . DS . 'gpg' . DS . 'serverkey.asc',
+                //'private' => CONFIG . DS . 'gpg' . DS . 'serverkey_private.asc',
             ],
         ],
     ],
@@ -124,8 +124,8 @@ return [
 //        'gpg' => [
 //            'serverKey' => [
 //                'fingerprint' => '2FC8945833C51946E937F9FED47B0811573EE67E',
-//                'public' => ROOT . DS . 'config' . DS . 'gpg' . DS . 'unsecure.key',
-//                'private' => ROOT . DS . 'config' . DS . 'gpg' . DS . 'unsecure_private.key',
+//                'public' => CONFIG . DS . 'gpg' . DS . 'unsecure.key',
+//                'private' => CONFIG . DS . 'gpg' . DS . 'unsecure_private.key',
 //            ],
 //        ],
 //    ]

--- a/src/Shell/Task/HealthcheckTask.php
+++ b/src/Shell/Task/HealthcheckTask.php
@@ -237,15 +237,15 @@ class HealthcheckTask extends AppShell
         $this->assert(
             $checks['configFile']['app'],
             __('The application config file is present'),
-            __('The application config file is missing in {0}', ROOT . DS . 'config'),
-            __('Copy {0} to {1}', ROOT . DS . 'config/app.php.default', ROOT . DS . 'config/app.php')
+            __('The application config file is missing in {0}', CONFIG),
+            __('Copy {0} to {1}', CONFIG . 'app.php.default', CONFIG . 'app.php')
         );
         $this->warning(
             $checks['configFile']['passbolt'],
             __('The passbolt config file is present'),
-            __('The passbolt config file is missing in {0}', ROOT . DS . 'config'),
+            __('The passbolt config file is missing in {0}', CONFIG),
             [
-                __('Copy {0} to {1}', 'config/passbolt.php.default', 'config/passbolt.php'),
+                __('Copy {0} to {1}', CONFIG . 'passbolt.php.default', CONFIG 'passbolt.php'),
                 __('The passbolt config file is not required if passbolt is configured with environment variables')
             ]
         );

--- a/src/Shell/Task/InstallTask.php
+++ b/src/Shell/Task/InstallTask.php
@@ -321,7 +321,7 @@ class InstallTask extends AppShell
             // Make sure the baseline config files are present
             $checks = Healthchecks::configFiles();
             if (!$checks['configFile']['app']) {
-                throw new Exception(__('The application config file is missing in {0}.', ROOT . DS . 'config'));
+                throw new Exception(__('The application config file is missing in {0}.', CONFIG));
             }
 
             // Check application url config


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [x] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did

Given `CONFIG` is available, there' s not reason to use `ROOT . DS . 'config'` instead. My use-case is that I change `CONFIG` in Debian packaging, so this inconsistency inflicts more changes than needed.