### PR TITLE
Enhance <link rel="icon"/> support

### DIFF
--- a/src/Template/Element/Header/meta.ctp
+++ b/src/Template/Element/Header/meta.ctp
@@ -20,4 +20,5 @@ use Cake\Routing\Router;
     <meta name="keywords" content="Passbolt, password manager, online password manager, open source password manager">
     <meta name="robots" content="<?= Configure::read('passbolt.meta.robots'); ?>">
     <meta name="viewport" content="width=device-width">
-    <link rel="shortcut icon" type="image/png" href="<?= Router::url('/favicon.ico'); ?>"/>
+    <link rel="shortcut icon" href="<?= Router::url('/favicon.ico'); ?>"/>
+    <link rel="icon" type="image/png" href="<?= Router::url('/favicon.png'); ?>"/>

--- a/src/Template/Element/Header/meta.ctp
+++ b/src/Template/Element/Header/meta.ctp
@@ -22,3 +22,8 @@ use Cake\Routing\Router;
     <meta name="viewport" content="width=device-width">
     <link rel="shortcut icon" href="<?= Router::url('/favicon.ico'); ?>"/>
     <link rel="icon" type="image/png" href="<?= Router::url('/favicon.png'); ?>"/>
+    <link rel="apple-touch-icon" href="<?= Router::url('/apple-touch-icon.png'); ?>"/>
+    <link rel="apple-touch-icon-precomposed" href="<?= Router::url('/apple-touch-icon-precomposed.png'); ?>"/>
+    <link rel="apple-touch-icon-precomposed" sizes="57x57" href="<?= Router::url('/apple-touch-icon-57x57-precomposed.png'); ?>"/>
+    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="<?= Router::url('/apple-touch-icon-72x72-precomposed.png'); ?>"/>
+    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="<?= Router::url('/apple-touch-icon-114x114-precomposed.png'); ?>"/>


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did

* Fix the `type` in the `favicon.ico` wrongly pretending the file is a png
* Add more `<link rel="icon"/>` lines for the files as shipped (`favicon.png` and all the `apple-touch*.png` files)