### PR TITLE
Use test data only when debug is true according to bootstrap_cli.php

### DIFF
--- a/plugins/PassboltTestData/src/Shell/Task/DataTask.php
+++ b/plugins/PassboltTestData/src/Shell/Task/DataTask.php
@@ -33,13 +33,15 @@ class DataTask extends Shell
     public function getOptionParser()
     {
         $parser = parent::getOptionParser();
-        $parser
-            ->setDescription(__('Populate the database with dummy data test.'))
-            ->addArgument('scenario', [
-                'help' => 'The scenario to play.',
-                'required' => true,
-                'choices' => array_keys(Configure::read('PassboltTestData.scenarios'))
-            ]);
+        if (Configure::read('debug') > 0) {
+            $parser
+                ->setDescription(__('Populate the database with dummy data test.'))
+                ->addArgument('scenario', [
+                    'help' => 'The scenario to play.',
+                    'required' => true,
+                    'choices' => array_keys(Configure::read('PassboltTestData.scenarios'))
+                ]);
+        }
 
         return $parser;
     }


### PR DESCRIPTION
This pull request is a 

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

### What you did
Passbolt healthcheck command always load test data.
On production server it's disaply this error on top of the output:

`Warning Error: array_keys() expects parameter 1 to be array, null given in [/var/www/passbolt_v2/plugins/PassboltTestData/src/Shell/Task/DataTask.php, line 41]`

I added controle of debug mode in the DataTask class like it exists in bootstrap_cli.php file.
