### PR TITLE
Make logic of unsafe mode test coherent with web FAQ

### DIFF
--- a/src/Template/Element/Footer/default.ctp
+++ b/src/Template/Element/Footer/default.ctp
@@ -19,7 +19,7 @@ $privacyPolicyUrl = Configure::read('passbolt.legal.privacy_policy.url');
 <footer>
     <div class="footer">
         <ul class="footer-links">
-<?php if (Configure::read('debug') || Configure::read('passbolt.ssl.force')) : ?>
+<?php if (Configure::read('debug') || !Configure::read('passbolt.ssl.force')) : ?>
             <li class="error message"><a href="https://help.passbolt.com/faq/hosting/why-unsafe" title="terms of service">Unsafe mode</a></li>
 <?php endif; ?>
             <li><a href="https://www.passbolt.com/terms" title="terms of service"><?= __('Terms'); ?></a></li>


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did

The (Why do I see an unsafe mode banner in the footer?)[https://help.passbolt.com/faq/hosting/why-unsafe] says:

> When running the site with debug mode on, or *without* enforcing https, …

… but the test implements:
>  When running the site with debug mode on, or *with* enforcing https, …

… which is backwards. :-)