### PR TITLE
Make sure unconfigured 'passbolt.plugins' doesn't break the extension

### DIFF
--- a/src/Controller/Settings/SettingsIndexController.php
+++ b/src/Controller/Settings/SettingsIndexController.php
@@ -98,7 +98,7 @@ class SettingsIndexController extends AppController
                 ],
                 'passbolt' => [
                     'edition' => Configure::read('passbolt.edition'),
-                    'plugins' => Configure::read('passbolt.plugins'),
+                    'plugins' => Configure::read('passbolt.plugins', []),
                 ],
             ];
         } else {
@@ -109,7 +109,7 @@ class SettingsIndexController extends AppController
                 ],
                 'passbolt' => [
                     'edition' => Configure::read('passbolt.edition'),
-                    'plugins' => array_fill_keys(array_keys(Configure::read('passbolt.plugins')), []),
+                    'plugins' => array_fill_keys(array_keys(Configure::read('passbolt.plugins'), []), []),
                 ],
             ];
 


### PR DESCRIPTION
This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did

If `passbolt.plugins` is not explicitely configured, the API's `settings.json` will serve it as `null`, breaking the extension's ability to decypher secrets. Adding a default empty array fixes this.
