### PR TITLE
Add Auto-Submitted header to the email notifications

### DIFF
--- a/src/Controller/Events/EmailNotificationsListener.php
+++ b/src/Controller/Events/EmailNotificationsListener.php
@@ -74,7 +74,8 @@ class EmailNotificationsListener implements EventListenerInterface
             'template' => $template,
             'subject' => Purifier::clean($subject),
             'format' => 'html',
-            'config' => 'default'
+            'config' => 'default',
+            'headers' => ['Auto-Submitted' => 'auto-generated']
         ];
         EmailQueue::enqueue($to, $data, $options);
     }


### PR DESCRIPTION
## Add Auto-Submitted header to the email notifications

This pull request is a (multiple allowed):

* [ ] bug fix
* [x] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did
The Auto-Submitted header was added to the email notifications. RFC3834 advises to set this header for automatic responses so that "out of the office" or "vacation" response generators and other automatic responders can identify and ignore (not reply to) those kind of messages.

