### PR TITLE
Modified variable used to specify tmp folder

### DIFF
--- a/config/paths.php
+++ b/config/paths.php
@@ -52,7 +52,7 @@ define('CONFIG', ROOT . DS . 'config' . DS);
 define('WWW_ROOT', ROOT . DS . 'webroot' . DS);
 
 /**
- * File path to the webroot directory.
+ * File path to the images directory.
  */
 define('IMAGES', WWW_ROOT . 'img' . DS);
 

--- a/src/Shell/Task/HealthcheckTask.php
+++ b/src/Shell/Task/HealthcheckTask.php
@@ -191,9 +191,9 @@ class HealthcheckTask extends AppShell
             [
                 __('Ensure the temporary directory and its content are writable by the user the webserver user.'),
                 __('you can try:'),
-                'sudo chown -R ' . PROCESS_USER . ':' . PROCESS_USER . ' ' . ROOT . 'tmp',
-                'sudo chmod 775 $(find ' . ROOT . 'tmp -type d)',
-                'sudo chmod 664 $(find ' . ROOT . 'tmp -type f)',
+                'sudo chown -R ' . PROCESS_USER . ':' . PROCESS_USER . ' ' . TMP,
+                'sudo chmod 775 $(find ' . TMP . ' -type d)',
+                'sudo chmod 664 $(find ' . TMP . ' -type f)',
             ]
         );
         $this->assert(


### PR DESCRIPTION
Previous behaviour would suggest a [HELP] text at healthcheck that
listed "/var/www/passbolttmp" in it's output. The code used ambigious
"ROOT . 'tmp'" notation, which should really be just 'TMP', since that
variable is specified in config/paths.php.

Also added minor update to comment in paths.php which named IMAGES directory
to be "webroot", which is wrong. Should be "images".