### PR TITLE
[WIP] Installation without PHP GnuPG extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "lorenzo/cakephp-email-queue": "^3.1",
         "burzum/file-storage": "1.2.1",
         "burzum/cakephp-imagine-plugin": "2.1.1",
+        "pear/crypt_gpg": "1.6.2",
         "ezyang/htmlpurifier": "dev-master"
     },
     "require-dev": {

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -30,8 +30,8 @@ if (!extension_loaded('mbstring')) {
     trigger_error('You must enable the mbstring extension to use Passbolt.', E_USER_ERROR);
 }
 
-if (!extension_loaded('gnupg')) {
-    trigger_error('You must enable the gnupg extension to use Passbolt.', E_USER_ERROR);
+if (!class_exists('Crypt_GPG')) {
+    trigger_error('You must install Crypt_GPG PEAR package to use Passbolt.', E_USER_ERROR);
 }
 
 if (!(extension_loaded('gd') || extension_loaded('imagick'))) {

--- a/src/Auth/GpgAuthenticate.php
+++ b/src/Auth/GpgAuthenticate.php
@@ -169,7 +169,7 @@ class GpgAuthenticate extends BaseAuthenticate
         } catch (Exception $e) {
             return $this->_error($e->getMessage());
         }
-        $this->_gpg->addsignkey(
+        $this->_gpg->addSignKey(
             $this->_config['serverKey']['fingerprint'],
             $this->_config['serverKey']['passphrase']
         );
@@ -183,7 +183,7 @@ class GpgAuthenticate extends BaseAuthenticate
 
         // encrypt and sign and send
         $token = 'gpgauthv1.3.0|36|' . $authenticationToken->token . '|gpgauthv1.3.0';
-        $msg = $this->_gpg->encryptsign($token);
+        $msg = $this->_gpg->encryptAndSign($token);
         $msg = quotemeta(urlencode($msg));
         $this->_response = $this->_response->withHeader('X-GPGAuth-User-Auth-Token', $msg);
 
@@ -268,15 +268,13 @@ class GpgAuthenticate extends BaseAuthenticate
         $keyid = $this->_config['serverKey']['fingerprint'];
 
         // check if the default key is set and available in gpg
-        $this->_gpg = new \gnupg();
-        $info = $this->_gpg->keyinfo($keyid);
-        $this->_gpg->seterrormode(\gnupg::ERROR_EXCEPTION);
-        if (empty($info)) {
+        $this->_gpg = new \Crypt_GPG();
+        if (empty($this->_checkKeyAvailability($keyid))) {
             throw new InternalErrorException(__('The OpenPGP server key defined in the config could not be found in the GnuPG keyring.'));
         }
 
         // set the key to be used for decrypting
-        if (!$this->_gpg->adddecryptkey($keyid, $this->_config['serverKey']['passphrase'])) {
+        if (!$this->_gpg->addDecryptKey($keyid, $this->_config['serverKey']['passphrase'])) {
             throw new InternalErrorException(__('The OpenPGP server key defined in the config cannot be used to decrypt.'));
         }
     }
@@ -290,18 +288,16 @@ class GpgAuthenticate extends BaseAuthenticate
      */
     private function _initUserKey(string $keyid)
     {
-        $info = $this->_gpg->keyinfo($keyid);
-        if (empty($info)) {
-            if (!$this->_gpg->import($this->_user->gpgkey->armored_key)) {
+        if (empty($this->_checkKeyAvailability($keyid))) {
+            if (!$this->_gpg->importKey($this->_user->gpgkey->armored_key)) {
                 throw new InternalErrorException(__('The OpenPGP key for the user could not be imported in GnuPG.'));
             }
             // check that the imported key match the fingerprint
-            $info = $this->_gpg->keyinfo($keyid);
-            if (empty($info)) {
+            if (empty($this->_checkKeyAvailability($keyid))) {
                 throw new InternalErrorException(__('GnuPGP does not return any information for the OpenPGP key of the user.'));
             }
         }
-        $this->_gpg->addencryptkey($keyid);
+        $this->_gpg->addEncryptKey($keyid);
     }
 
     /**
@@ -337,6 +333,20 @@ class GpgAuthenticate extends BaseAuthenticate
         }
 
         return $user;
+    }
+
+    /**
+     * Check from key fingerprint if key is present in keyring
+     * @param string $keyid key id
+     * @return array
+     */
+    private function _checkKeyAvailability($keyid)
+    {
+        $keys = array_filter($this->_gpg->getKeys(), function($key) use ($keyid) {
+            return $key->getPrimaryKey()->getFingerPrint() === strtoupper($keyid);
+        }, ARRAY_FILTER_USE_BOTH);
+
+        return $keys;
     }
 
     /**

--- a/src/Middleware/GpgAuthSignMiddleware.php
+++ b/src/Middleware/GpgAuthSignMiddleware.php
@@ -33,13 +33,12 @@ class GpgAuthSignMiddleware
         // Sign the successfull json responses
         if ($response->statusCode() === 200 && $request->is('json')) {
             $body = (string)$response->getBody();
-            $gpg = new \gnupg();
-            $gpg->addsignkey(
+            $gpg = new \Crypt_GPG();
+            $gpg->addSignKey(
                 Configure::read('passbolt.gpg.serverKey.fingerprint'),
                 Configure::read('passbolt.gpg.serverKey.passphrase')
             );
-            $gpg->setsignmode(\gnupg::SIG_MODE_DETACH);
-            $signed = $gpg->sign($body);
+            $signed = $gpg->sign($body, \Crypt_GPG::SIGN_MODE_DETACHED);
 
             $response = $response->withHeader(self::HTTP_HEADER_GPG_SIG_BODY, quotemeta(urlencode($signed)));
         }


### PR DESCRIPTION
## Installation without PHP GnuPG extension

This pull request is a (multiple allowed):

* [ ] bug fix
* [x] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
This request is not really intended to be merged.

It's a quickly done proof of concept of [GnuPG](http://php.net/manual/fr/book.gnupg.php) PHP extension's replacement by PEAR package [Crypt_GPG](https://pear.php.net/package/Crypt_GPG) that relies on GnuPG binary to show minors changes that involved, in response to [feature request](https://community.passbolt.com/t/as-an-admin-i-can-install-passbolt-without-the-need-of-gnupg-extension/176) following this [issue](https://community.passbolt.com/t/installation-without-php-gnupg-extension/170).

Gpg class utility could be a direct wrapper of GPG binary without much effort.
Let me know if you could be interested by  this solution.