### PR TITLE
fix fingerprint not found when recover a account

### DIFF
--- a/src/Controller/Auth/AuthVerifyController.php
+++ b/src/Controller/Auth/AuthVerifyController.php
@@ -48,7 +48,7 @@ class AuthVerifyController extends AppController
             $msg = __('The public key information was not found in config.');
             throw new InternalErrorException($msg);
         }
-        $file = new File(Configure::read('passbolt.gpg.serverKey.public'));
+        $file = new File('../'.Configure::read('passbolt.gpg.serverKey.public'));
         if (!$file->exists()) {
             throw new InternalErrorException(__('The public key for this passbolt instance was not found.'));
         }


### PR DESCRIPTION
## Could not retrieve server key. Please contact administrator
[https://community.passbolt.com/t/could-not-retrieve-server-key-please-contact-administrator/720](https://community.passbolt.com/t/could-not-retrieve-server-key-please-contact-administrator/720)

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
When recover account the system not found the fingerprint key.
It search in the wrong path (/webroot/) instead the root directory.
