### PR TITLE
Change links in default.ctp to use full url

### DIFF
--- a/src/Template/Element/Navigation/default.ctp
+++ b/src/Template/Element/Navigation/default.ctp
@@ -22,9 +22,9 @@ use Cake\Core\Configure;
             <div class="top navigation primary">
                 <ul>
                     <li class="left"><a href="<?= Router::url('/') ?>"><span><?= __('home') ?></span></a></li>
-                    <li class="right"><a href="<?= Router::url('/auth/login') ?>"><span><?= __('login') ?></span></a></li>
+                    <li class="right"><a href="<?= Router::url('/auth/login', true) ?>"><span><?= __('login') ?></span></a></li>
 <?php if (Configure::read('passbolt.registration.public') === true) : ?>
-                    <li class="right"><a href="<?= Router::url('/users/register') ?>"><span><?= __('register') ?></span></a></li>
+                    <li class="right"><a href="<?= Router::url('/users/register', true) ?>"><span><?= __('register') ?></span></a></li>
 <?php endif; ?>
                 </ul>
             </div>


### PR DESCRIPTION
Using the full url is necessary when running passbolt under a subfolder, so the login link will point for instance to /passbolt/auth/login

##IMPORTANT: PLEASE READ

The best way to propose a feature is to open an issue on the community forum and discuss your 
ideas there before implementing them: https://community.passbolt.com/

This is only a issue tracker for issues related to the Passbolt API.
For passbolt docker, browser extension, command line interface, in short any other issues 
please use this [the other relevant repositories](https://github.com/passbolt).

Always follow the contribution guidelines when submitting a pull request.
In particular, make sure existing tests still pass, and add unit and selenium tests for all new behavior. When fixing a bug, 
you may want to add a test to verify the fix.

Please follow the following format:

## ISSUE NAME

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
Describe the big picture of your changes here to communicate to the maintainers why we 
should accept this pull request. If it fixes a bug or resolves a feature request, be sure 
to link to that issue.
