### PR TITLE
Fix spelling issue

### DIFF
--- a/src/Shell/Task/HealthcheckTask.php
+++ b/src/Shell/Task/HealthcheckTask.php
@@ -449,7 +449,7 @@ class HealthcheckTask extends AppShell
         $this->assert(
             $checks['application']['sslForce'],
             __('Passbolt is configured to force SSL use.'),
-            __('Passbot is not configured to force SSL use.'),
+            __('Passbolt is not configured to force SSL use.'),
             __('Set passbolt.ssl.force to true in config/passbolt.php.')
         );
         $this->assert(


### PR DESCRIPTION
Passbot -> Passbolt

## Fix spelling issue

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [x] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did
I fixed a spelling issue in a use of the name of the project