### PR TITLE
Correct path to cake cli in error message

### DIFF
--- a/src/Shell/AppShell.php
+++ b/src/Shell/AppShell.php
@@ -62,7 +62,7 @@ class AppShell extends Shell
             $this->_error('Passbolt commands cannot be executed as root.', false);
             $this->out('');
             $this->out('The command should be executed with the same user as your web server. By instance:');
-            $this->out('su -s /bin/bash -c "' . APP . 'Console/cake COMMAND" HTTP_USER');
+            $this->out('su -s /bin/bash -c "' . ROOT . '/bin/cake COMMAND" HTTP_USER');
             $this->out('where HTTP_USER match your web server user: www-data, nginx, http');
             $this->out('');
 


### PR DESCRIPTION
The error message of "Passbolt commands cannot be executed as root" is pointing to a path where the cake cli script cannot be found any more. This commit fixes the path in the output.