### PR TITLE
fix(migrations): sql migrations were failing when database name conta…

### DIFF
--- a/config/Migrations/20170830064410_V162InitialMigration.php
+++ b/config/Migrations/20170830064410_V162InitialMigration.php
@@ -60,7 +60,7 @@ class V162InitialMigration extends AbstractMigration
         }
 
         // Reset the collation just in case
-        $this->execute('ALTER DATABASE ' . $databaseName . ' COLLATE utf8mb4_unicode_ci');
+        $this->execute('ALTER DATABASE `' . $databaseName . '` COLLATE utf8mb4_unicode_ci');
 
         // If this is an upgrade from v1
         if ($tableCount > 0) {


### PR DESCRIPTION
## Migrations crashes when database name contains dashes

This pull request is a (multiple allowed):

* [x] bug fix