### PR TITLE
Make passbolt work without the php gnupg extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     "config": {
       "optimize-autoloader": true,
       "platform": {
-        "php": "7.0.33"
-      }
+            "php": "7.4.3"
+        }
     },
     "homepage": "https://www.passbolt.com",
     "license": "AGPL-3.0-or-later",
@@ -51,7 +51,9 @@
         "donatj/phpuseragentparser": "^0.7.0",
         "lorenzo/cakephp-email-queue": "^3.3.1",
         "burzum/cakephp-file-storage": "^2.1.0",
-        "burzum/cakephp-imagine-plugin": "3.x-dev"
+        "burzum/cakephp-imagine-plugin": "3.x-dev",
+        "phar-io/gnupg": "^1.0",
+        "pear/crypt_gpg": "^1.6"
     },
     "require-dev": {
         "psy/psysh": "@stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1f03097b7ae6d12743e0fa68fdb936d",
+    "content-hash": "655da4476143edc4e6d18a404fdc5ace",
     "packages": [
         {
             "name": "aura/intl",
@@ -938,6 +938,310 @@
                 "random"
             ],
             "time": "2018-07-02T15:55:56+00:00"
+        },
+        {
+            "name": "pear/console_commandline",
+            "version": "v1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Console_CommandLine.git",
+                "reference": "331b295d00c9fa2dae30fe14538d430d72d954c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Console_CommandLine/zipball/331b295d00c9fa2dae30fe14538d430d72d954c6",
+                "reference": "331b295d00c9fa2dae30fe14538d430d72d954c6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "pear/pear_exception": "^1.0.0",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Console": "./"
+                },
+                "exclude-from-classmap": [
+                    "tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                ""
+            ],
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Richard Quadling",
+                    "email": "rquadling@gmail.com"
+                },
+                {
+                    "name": "David Jean Louis",
+                    "email": "izimobil@gmail.com"
+                }
+            ],
+            "description": "A full featured command line options and arguments parser.",
+            "homepage": "https://github.com/pear/Console_CommandLine",
+            "keywords": [
+                "console"
+            ],
+            "time": "2020-04-16T15:04:15+00:00"
+        },
+        {
+            "name": "pear/crypt_gpg",
+            "version": "v1.6.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/Crypt_GPG.git",
+                "reference": "7aa6a2a2b0017acb7eb9adf109ee4bfee0bf1d2f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/Crypt_GPG/zipball/7aa6a2a2b0017acb7eb9adf109ee4bfee0bf1d2f",
+                "reference": "7aa6a2a2b0017acb7eb9adf109ee4bfee0bf1d2f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "pear/console_commandline": "*",
+                "pear/pear_exception": "*",
+                "php": ">=5.4.8"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6 || ^7"
+            },
+            "suggest": {
+                "ext-posix": "May require the posix PHP extension"
+            },
+            "bin": [
+                "scripts/crypt-gpg-pinentry"
+            ],
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "Crypt/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Gauthier",
+                    "email": "mike@silverorange.com"
+                },
+                {
+                    "name": "Nathan Fredrickson",
+                    "email": "nathan@silverorange.com"
+                },
+                {
+                    "name": "Aleksander Machniak",
+                    "email": "alec@alec.pl"
+                }
+            ],
+            "description": "Provides an object oriented interface to the GNU Privacy Guard (GnuPG). It requires the GnuPG executable to be on the system.",
+            "homepage": "https://github.com/pear/Crypt_GPG",
+            "keywords": [
+                "PGP",
+                "encryption",
+                "gnupg",
+                "gpg"
+            ],
+            "time": "2020-03-22T11:49:18+00:00"
+        },
+        {
+            "name": "pear/pear_exception",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pear/PEAR_Exception.git",
+                "reference": "dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pear/PEAR_Exception/zipball/dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7",
+                "reference": "dbb42a5a0e45f3adcf99babfb2a1ba77b8ac36a7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=4.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "class",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PEAR/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "."
+            ],
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Helgi Thormar",
+                    "email": "dufuz@php.net"
+                },
+                {
+                    "name": "Greg Beaver",
+                    "email": "cellog@php.net"
+                }
+            ],
+            "description": "The PEAR Exception base class.",
+            "homepage": "https://github.com/pear/PEAR_Exception",
+            "keywords": [
+                "exception"
+            ],
+            "time": "2019-12-10T10:24:42+00:00"
+        },
+        {
+            "name": "phar-io/executor",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/executor.git",
+                "reference": "5bfb7400224a0c1cf83343660af85c7f5a073473"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/executor/zipball/5bfb7400224a0c1cf83343660af85c7f5a073473",
+                "reference": "5bfb7400224a0c1cf83343660af85c7f5a073473",
+                "shasum": ""
+            },
+            "require": {
+                "phar-io/filesystem": "^2.0",
+                "php": "^7.2||^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                }
+            ],
+            "time": "2020-11-30T10:53:57+00:00"
+        },
+        {
+            "name": "phar-io/filesystem",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/filesystem.git",
+                "reference": "222e3ea432262a05706b7066697c21257664d9d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/filesystem/zipball/222e3ea432262a05706b7066697c21257664d9d1",
+                "reference": "222e3ea432262a05706b7066697c21257664d9d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                }
+            ],
+            "time": "2020-11-30T10:16:22+00:00"
+        },
+        {
+            "name": "phar-io/gnupg",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/gnupg.git",
+                "reference": "3c106d39f62ba3941f830ca24e125cb1b9290a87"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/gnupg/zipball/3c106d39f62ba3941f830ca24e125cb1b9290a87",
+                "reference": "3c106d39f62ba3941f830ca24e125cb1b9290a87",
+                "shasum": ""
+            },
+            "require": {
+                "phar-io/executor": "^1.0",
+                "phar-io/filesystem": "^2.0",
+                "php": "^7.2||^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Thin GnuPG wrapper class around the gnupg binary, mimicking the pecl/gnupg api",
+            "time": "2020-11-30T10:21:26+00:00"
         },
         {
             "name": "phpseclib/phpseclib",
@@ -2488,6 +2792,7 @@
                 "extension",
                 "twig"
             ],
+            "abandoned": "twig/cache-extension",
             "time": "2020-01-01T20:47:37+00:00"
         },
         {
@@ -3401,20 +3706,21 @@
         },
         {
             "name": "passbolt/passbolt_test_data",
-            "version": "2.13.1",
+            "version": "2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/passbolt/passbolt_test_data.git",
-                "reference": "7768361704d7b79f1323f674b3825043eafe65b3"
+                "reference": "acfae89a3f039f6debcb6a87d221896a54cd121e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/passbolt/passbolt_test_data/zipball/7768361704d7b79f1323f674b3825043eafe65b3",
-                "reference": "7768361704d7b79f1323f674b3825043eafe65b3",
+                "url": "https://api.github.com/repos/passbolt/passbolt_test_data/zipball/acfae89a3f039f6debcb6a87d221896a54cd121e",
+                "reference": "acfae89a3f039f6debcb6a87d221896a54cd121e",
                 "shasum": ""
             },
             "require": {
-                "cakephp/cakephp": "^3.7"
+                "cakephp/cakephp": "^3.7",
+                "ext-json": "*"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7|^6.0"
@@ -3451,7 +3757,7 @@
                 "help": "https://www.passbolt.com/help",
                 "source": "https://github.com/passbolt/passbolt"
             },
-            "time": "2020-06-05T08:01:37+00:00"
+            "time": "2020-10-23T05:57:36+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -4016,6 +4322,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -5424,7 +5731,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.0.33"
+        "php": "7.4.3"
     },
     "plugin-api-version": "1.1.0"
 }

--- a/config/passbolt.default.php
+++ b/config/passbolt.default.php
@@ -110,6 +110,18 @@ return [
             // Replace GNUPGHOME with above value even if it is set.
             //'putenv' => false,
 
+            // Which backend to use for encryption:
+            // - 'gnupg' uses the php gnupg extension.
+            // - 'cryptGPG' uses the pecl Crypt_GPG package instead (requires the gpg command but not the gnupg extension)
+            'backend' => 'gnupg',
+
+            // Additional options for the constructor of the Crypt_GPG php class.
+            // These settings are only used when backend is set to 'cryptGPG'.
+            // See: Crypt_GPGAbstract::__construct (https://pear.php.net/package/Crypt_GPG/docs/latest/Crypt_GPG/Crypt_GPGAbstract.html)
+            // for a full list of options.
+            //'cryptGpg' => [
+            //],
+
             // Main server key.
             'serverKey' => [
                 // Server private key fingerprint.

--- a/config/requirements.php
+++ b/config/requirements.php
@@ -27,9 +27,9 @@ if (!extension_loaded('mbstring')) {
 /*
  *  Passbolt requirements
  */
-if (!extension_loaded('gnupg')) {
-    trigger_error('You must enable the gnupg extension to use Passbolt.', E_USER_ERROR);
-}
+// if (!extension_loaded('gnupg')) {
+//    trigger_error('You must enable the gnupg extension to use Passbolt.', E_USER_ERROR);
+//}
 
 if (!(extension_loaded('gd') || extension_loaded('imagick'))) {
     trigger_error('You must enable the gd or imagick extensions to use Passbolt.', E_USER_ERROR);

--- a/src/Utility/Healthchecks/GpgHealthchecks.php
+++ b/src/Utility/Healthchecks/GpgHealthchecks.php
@@ -92,6 +92,7 @@ class GpgHealthchecks
     {
         switch (Configure::read('passbolt.gpg.backend')) {
             case OpenPGPBackendFactory::GNUPG:
+            case OpenPGPBackendFactory::CRYPT_GPG:
                 // If no keyring location has been set, use the default one ~/.gnupg.
                 $gnupgHome = getenv('GNUPGHOME');
                 if (empty($gnupgHome)) {

--- a/src/Utility/OpenPGP/Backends/CryptGPG.php
+++ b/src/Utility/OpenPGP/Backends/CryptGPG.php
@@ -1,0 +1,654 @@
+<?php
+/**
+ * Passbolt ~ Open source password manager for teams
+ * Copyright (c) Passbolt SA (https://www.passbolt.com)
+ *
+ * Licensed under GNU Affero General Public License version 3 of the or any later version.
+ * For full copyright and license information, please see the LICENSE.txt
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Passbolt SA (https://www.passbolt.com)
+ * @license       https://opensource.org/licenses/AGPL-3.0 AGPL License
+ * @link          https://www.passbolt.com Passbolt(tm)
+ * @since         2.0.0
+ */
+namespace App\Utility\OpenPGP\Backends;
+
+use App\Utility\OpenPGP\OpenPGPBackend;
+use Cake\Core\Configure;
+use Cake\Core\Exception\Exception;
+use OpenPGP as OpenPGP;
+use OpenPGP_Message as OpenPGP_Message;
+use OpenPGP_PublicKeyPacket as OpenPGP_PublicKeyPacket;
+use OpenPGP_SecretKeyPacket as OpenPGP_SecretKeyPacket;
+
+/**
+ * This class provides tools for Gpg operations.
+ * It is an alternative implementation to the default OpenPGPBackend implementation that uses the php gnupg extension.
+ * Instead this uses the Crypt_GPG pear package that calls the gpg command on the shell.
+ */
+class CryptGPG extends OpenPGPBackend
+{
+    /**
+     * Gpg object.
+     */
+    protected $_gpg = null;
+
+    /**
+     * Constructor.
+     *
+     * @throws Exception
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (!class_exists('Crypt_GPG')) {
+            trigger_error('You must install Crypt_GPG PEAR package to use Passbolt.', E_USER_ERROR);
+        }
+
+        if (Configure::read('passbolt.gpg.putenv')) {
+            putenv('GNUPGHOME=' . Configure::read('passbolt.gpg.keyring'));
+        }
+
+        $options = array();
+        if (Configure::read('passbolt.gpg.cryptGpg')) {
+            $options = Configure::read('passbolt.gpg.cryptGpg');
+        }
+
+        $this->_gpg = new \Crypt_GPG($options);
+    }
+
+    /**
+     * Set a key for encryption.
+     *
+     * @param string $armoredKey ASCII armored key data
+     * @throws Exception if the key cannot be used to encrypt
+     * @return bool true if success
+     */
+    public function setEncryptKey(string $armoredKey)
+    {
+        $this->_encryptKeyFingerprint = null;
+        // Get the key info.
+        $encryptKeyInfo = $this->getPublicKeyInfo($armoredKey);
+        $fingerprint = $encryptKeyInfo['fingerprint'];
+
+        try {
+            $this->_gpg->addEncryptKey($fingerprint);
+            $this->_encryptKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            // It didn't work, maybe only key is not in the keyring
+            // we import the key and retry
+            $this->importKeyIntoKeyring($armoredKey);
+            try {
+                $this->_gpg->addEncryptKey($fingerprint);
+                $this->_encryptKeyFingerprint = $fingerprint;
+            } catch (\Exception $e) {
+                throw new Exception(__('The key {0} cannot be used to encrypt.', $fingerprint));
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Set a key for encryption.
+     *
+     * @param string $fingerprint fingerprint
+     * @throws Exception if key is not present in keyring
+     * @throws Exception if there was an issue to use the key to encrypt
+     * @return bool true if success
+     */
+    public function setEncryptKeyFromFingerprint(string $fingerprint)
+    {
+        $this->_encryptKeyFingerprint = null;
+        $this->assertKeyInKeyring($fingerprint);
+        try {
+            $this->_gpg->addEncryptKey($fingerprint);
+            $this->_encryptKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            throw new Exception(__('The key {0} cannot be used to encrypt.', $fingerprint));
+        }
+
+        return true;
+    }
+
+    /**
+     * Set a key for decryption.
+     *
+     * @param string $armoredKey ASCII armored key data
+     * @param string $passphrase to decrypt secret key
+     * @throws Exception if the key cannot be found in the keyring
+     * @throws Exception if the key is using a passphrase
+     * @throws Exception if the key cannot be used to decrypt
+     * @return bool true if success
+     */
+    public function setDecryptKey(string $armoredKey, string $passphrase)
+    {
+        $this->_decryptKeyFingerprint = null;
+
+        // Get the key info.
+        $decryptKeyInfo = $this->getKeyInfo($armoredKey);
+        $fingerprint = $decryptKeyInfo['fingerprint'];
+
+        try {
+            $this->_gpg->addDecryptKey($fingerprint, $passphrase);
+            $this->_decryptKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            // It didn't work, maybe only key is not in the keyring
+            // we import the key and retry
+            $this->importKeyIntoKeyring($armoredKey);
+            try {
+                $this->_gpg->addDecryptKey($fingerprint, $passphrase);
+                $this->_decryptKeyFingerprint = $fingerprint;
+            } catch (\Exception $e) {
+                $msg = __('The key {0} cannot be used to decrypt.', $fingerprint);
+                throw new Exception($msg . ' ' . $e->getMessage());
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Set a key for decryption.
+     *
+     * @param string $fingerprint fingerprint of a key in the keyring
+     * @param string $passphrase to decrypt secret key
+     * @throws Exception if the key cannot be found in the keyring
+     * @throws Exception if the key is using a passphrase
+     * @throws Exception if the key cannot be used to decrypt
+     * @return bool true if success
+     */
+    public function setDecryptKeyFromFingerprint(string $fingerprint, string $passphrase)
+    {
+        $this->_decryptKeyFingerprint = null;
+
+        try {
+            $this->_gpg->addDecryptKey($fingerprint, $passphrase);
+            $this->_decryptKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            throw new Exception(__('The key {0} cannot be used to decrypt.', $fingerprint));
+        }
+
+        return true;
+    }
+
+    /**
+     * Set a key for signing.
+     *
+     * @param string $armoredKey ASCII armored key data
+     * @param string $passphrase passphrase
+     * @throws Exception if the key is not already in the keyring
+     * @throws Exception if the passphrase is not empty
+     * @throws Exception if the key cannot be used for signing
+     * @return bool
+     * @throws Exception
+     */
+    public function setSignKey(string $armoredKey, string $passphrase)
+    {
+        $this->_signKeyFingerprint = null;
+
+        $signKeyInfo = $this->getKeyInfo($armoredKey);
+        $fingerprint = $signKeyInfo['fingerprint'];
+
+        try {
+            // The key is in the keyring try to use it as a sign key
+            $this->_gpg->addSignKey($fingerprint, $passphrase);
+            $this->_signKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            // It didn't work, maybe only public key was in the keyring
+            // we try to re-import the key
+            $this->importKeyIntoKeyring($armoredKey);
+            try {
+                $this->_gpg->addSignKey($fingerprint, $passphrase);
+                $this->_signKeyFingerprint = $fingerprint;
+            } catch (\Exception $e) {
+                $msg = __('Could not use key {0} for signing.', $fingerprint);
+                throw new Exception($msg . ' ' . $e->getMessage());
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Set key to be used for signing
+     *
+     * @throws Exception if the key is not already in the keyring
+     * @throws Exception if the passphrase is not empty
+     * @throws Exception if the key cannot be used for signing
+     * @param string $fingerprint fingerprint
+     * @param string $passphrase passphrase
+     * @return true if success
+     */
+    public function setSignKeyFromFingerprint(string $fingerprint, string $passphrase)
+    {
+        $this->_signKeyFingerprint = null;
+
+        try {
+            $this->_gpg->addSignKey($fingerprint, $passphrase);
+            $this->_signKeyFingerprint = $fingerprint;
+        } catch (\Exception $e) {
+            $msg = __('Could not use key {0} for signing.', $fingerprint);
+            throw new Exception($msg . ' ' . $e->getMessage());
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if an ASCII armored public key is parsable
+     *
+     * To do this, we try to unarmor the key. If the operation is successful, then we consider that
+     * the key is a valid one.
+     *
+     * @param string $armoredKey ASCII armored key data
+     * @return bool true if valid, false otherwise
+     */
+    public function isParsableArmoredPublicKey(string $armoredKey)
+    {
+        try {
+            $this->assertGpgMarker($armoredKey, self::PUBLIC_KEY_MARKER);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        // If we don't manage to unarmor the key, we consider it's not a valid one.
+        $keyUnarmored = OpenPGP::unarmor($armoredKey, self::PUBLIC_KEY_MARKER);
+        if ($keyUnarmored === false) {
+            return false;
+        }
+
+        // Try to parse the key
+        // @codingStandardsIgnoreStart
+        $publicKey = @(\OpenPGP_PublicKeyPacket::parse($keyUnarmored));
+        // @codingStandardsIgnoreEnd
+        if (empty($publicKey) || empty($publicKey->fingerprint) || empty($publicKey->key)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if an ASCII armored private key is parsable
+     *
+     * To do this, we try to unarmor the key. If the operation is successful, then we consider that
+     * the key is a valid one.
+     *
+     * @param  string $armoredKey ASCII armored key data
+     * @return bool true if parsable false otherwise
+     */
+    public function isParsableArmoredPrivateKey(string $armoredKey)
+    {
+        try {
+            $this->assertGpgMarker($armoredKey, self::PRIVATE_KEY_MARKER);
+        } catch (Exception $e) {
+            return false;
+        }
+
+        // If we don't manage to unarmor the key, we consider it's not a valid one.
+        $keyUnarmored = OpenPGP::unarmor($armoredKey, self::PRIVATE_KEY_MARKER);
+        if ($keyUnarmored == false) {
+            return false;
+        }
+
+        // Try to parse the key
+        // @codingStandardsIgnoreStart
+        $privateKey = @(OpenPGP_SecretKeyPacket::parse($keyUnarmored));
+        // @codingStandardsIgnoreEnd
+        if (empty($privateKey) || empty($privateKey->fingerprint) || empty($privateKey->key)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if an ASCII armored signed message is parsable
+     *
+     * @param  string $armored ASCII armored signed message
+     * @return bool
+     */
+    public function isParsableArmoredSignedMessage($armored)
+    {
+        try {
+            $marker = $this->getGpgMarker($armored);
+        } catch (Exception $e) {
+            return false;
+        }
+        if ($marker !== self::SIGNED_MESSAGE_MARKER) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if a message is valid.
+     *
+     * To do this, we try to unarmor the message. If the operation is successful, then we consider that
+     * the message is a valid one.
+     *
+     * @param string $armored ASCII armored message data
+     * @return bool true if valid, false otherwise
+     */
+    public function isValidMessage(string $armored)
+    {
+        try {
+            $this->assertGpgMarker($armored, self::MESSAGE_MARKER);
+        } catch (Exception $e) {
+            return false;
+        }
+        $unarmored = OpenPGP::unarmor($armored, self::MESSAGE_MARKER);
+
+        return !($unarmored === false || $unarmored === null);
+    }
+
+    /**
+     * Get public key information.
+     *
+     * @param string $armoredKey the ASCII armored key block
+     * @throws Exception if the armored key cannot be parsed
+     * @return array key information (see getKeyInfo)
+     */
+    public function getPublicKeyInfo(string $armoredKey)
+    {
+        if (
+            $this->isParsableArmoredPublicKey($armoredKey) === false
+            && $this->isParsableArmoredPrivateKey($armoredKey) === false
+        ) {
+            throw new Exception(__('The public key could not be parsed.'));
+        }
+
+        return $this->getKeyInfo($armoredKey);
+    }
+
+    /**
+     * Get key information
+     *
+     * Extract the information from the key and return them in an array:
+     *  - fingerprint   : fingerprint of the key, string(40)
+     *  - bits          : size / number of bits (int)
+     *  - type          : algorithm used by the key (RSA, ELGAMAL, DSA, etc..)
+     *  - key_id        : key id, string(8)
+     *  - key_created   : date of creation of the key, timestamp
+     *  - uid           : user id of the key following gpg standard (usually name surname (comment) <email>), string
+     *  - expires       : expiration date or empty if no expiration date, timestamp
+     *
+     * Important note : this function is using OpenPgp-PHP library instead of php-gnupg to pre-validate the key.
+     *
+     * @param string $armoredKey the ASCII armored key block
+     * @return array as described above
+     */
+    public function getKeyInfo(string $armoredKey)
+    {
+        // Unarmor the key.
+        $keyUnarmored = OpenPGP::unarmor($armoredKey, $this->getGpgMarker($armoredKey));
+
+        // Get the message.
+        $msg = OpenPGP_Message::parse($keyUnarmored);
+
+        // Parse public key.
+        $publicKey = OpenPGP_PublicKeyPacket::parse($keyUnarmored);
+
+        // Get Packets for public key.
+        $publicKeyPacket = $msg->packets[0];
+
+        // If the packet is not a valid publicKey Packet, then we can't retrieve the uid.
+        if (!$publicKeyPacket instanceof OpenPGP_PublicKeyPacket) {
+            throw new Exception(__('Invalid key. No public key package found.'));
+        }
+
+        // Get userId.
+        $userIds = [];
+        foreach ($msg->signatures() as $signatures) {
+            foreach ($signatures as $signature) {
+                if ($signature instanceof \OpenPGP_UserIDPacket) {
+                    $userIds[] = sprintf('%s', $signature);
+                }
+            }
+        }
+
+        // Retrieve algorithm type.
+        $type = OpenPGP_PublicKeyPacket::$algorithms[$publicKeyPacket->algorithm];
+
+        // Retrieve key size.
+        $bits = 0;
+        if (isset(OpenPGP_PublicKeyPacket::$key_fields[$publicKeyPacket->algorithm])) {
+            $keyFirstElt = OpenPGP_PublicKeyPacket::$key_fields[$publicKeyPacket->algorithm][0];
+            $bits = OpenPGP::bitlength($publicKeyPacket->key[$keyFirstElt]);
+        }
+
+        // Build key information array.
+        $info = [
+            'key_id' => $publicKeyPacket->key_id,
+            'fingerprint' => $publicKeyPacket->fingerprint(),
+            'key_created' => $publicKey->timestamp,
+            'expires' => $publicKeyPacket->expires($msg),
+            'bits' => $bits,
+            'type' => $type,
+            'uid' => $userIds[0],
+        ];
+
+        return $info;
+    }
+
+    /**
+     * Is key currently in keyring
+     *
+     * @param string $fingerprint fingerprint
+     * @return bool true if in keyring false otherwise
+     */
+    public function isKeyInKeyring(string $fingerprint)
+    {
+        try {
+            $keys = array_filter($this->_gpg->getKeys(), function($key) use ($fingerprint) {
+                return $key->getPrimaryKey()->getFingerPrint() === strtoupper($fingerprint);
+            }, ARRAY_FILTER_USE_BOTH);
+        } catch (\Exception $e) {
+            return false;
+        }
+        if (empty($keys) || $keys === false) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Import a key into the local keyring.
+     *
+     * @param string $armoredKey the ASCII armored key block
+     * @throws Exception if the key could not be imported
+     * @return string key fingerprint
+     */
+    public function importKeyIntoKeyring(string $armoredKey)
+    {
+        $msg = __('Could not import the key.');
+        try {
+            $import = $this->_gpg->importKey($armoredKey);
+        } catch (\Exception $e) {
+            throw new Exception($msg);
+        }
+        if (!is_array($import)) {
+            throw new Exception($msg);
+        }
+        if (!isset($import['fingerprint'])) {
+            throw new Exception($msg);
+        }
+
+        return $import['fingerprint'];
+    }
+
+    /**
+     * Encrypt a text and optionally sign it too
+     * Do not forget to add a key to encrypt and optionally to sign
+     *
+     * @param string $text plain text to be encrypted.
+     * @param bool $sign whether the encrypted message should be signed.
+     * @throws Exception if no key was set to encrypt and optionally to sign
+     * @throws Exception if there is an issue with the key to encrypt and optionally to sign
+     * @return string encrypted text
+     */
+    public function encrypt(string $text, bool $sign = false)
+    {
+        $this->assertEncryptKey();
+        if ($sign === true) {
+            $msg = __('Could not use the key to sign and encrypt.');
+            $this->assertSignKey();
+            try {
+                $encryptedText = $this->_gpg->encryptAndSign($text);
+            } catch (\Exception $e) {
+                throw new Exception($msg . $e->getMessage());
+            }
+            if ($encryptedText === false) {
+                throw new Exception($msg);
+            }
+            $this->clearSignKeys();
+        } else {
+            $msg = __('Could not use the key to encrypt.');
+            $this->assertEncryptKey();
+            try {
+                $encryptedText = $this->_gpg->encrypt($text);
+            } catch (\Exception $e) {
+                throw new Exception($msg . ' ' . $e->getMessage());
+            }
+            if ($encryptedText === false) {
+                throw new Exception($msg);
+            }
+        }
+        $this->clearDecryptKeys();
+
+        return $encryptedText;
+    }
+
+    /**
+     * Decrypt a text
+     *
+     * @param string $text ASCII armored encrypted text to be decrypted.
+     * @param bool $verifySignature should signature be verified
+     * @throws Exception if decryption fails
+     * @return string decrypted text
+     */
+    public function decrypt(string $text, bool $verifySignature = false)
+    {
+        $decrypted = false;
+        $this->assertDecryptKey();
+        if ($verifySignature) {
+            $this->assertVerifyKey();
+            $fingerprint = $this->_verifyKeyFingerprint;
+            $this->clearVerifyKeys();
+        }
+        try {
+            if ($verifySignature === false) {
+                $decrypted = $this->_gpg->decrypt($text);
+            } else {
+                $v = $this->_gpg->decryptAndVerify($text);
+                $signatureInfo = $v['signatures'];
+                $decrypted = $v['data'];
+            }
+        } catch (\Exception $e) {
+            $this->clearDecryptKeys();
+            throw new Exception(__('Decryption failed.'));
+        }
+        $this->clearDecryptKeys();
+
+        if ($decrypted === false) {
+            throw new Exception(__('Decryption failed.'));
+        }
+        if ($verifySignature) {
+            if (empty($signatureInfo) || $signatureInfo[0]->getKeyFingerprint() !== $fingerprint) {
+                $msg = __('Expected {0} and got {1}.', $fingerprint, $signatureInfo[0]->getKeyFingerprint());
+                $msg = __('Decryption failed. Invalid signature.') . ' ' . $msg;
+                throw new Exception($msg);
+            }
+        }
+
+        return $decrypted;
+    }
+
+    /**
+     * Verify a signed message.
+     *
+     * @param string $armored The armored signed message to verify.
+     * @param string $fingerprint The fingerprint of the key to verify for.
+     * @param mixed $plainText (optional) if this parameter is passed, it will be filled with the plain text.
+     * @return void
+     * @throws Exception If the armored signed message cannot be verified.
+     */
+    public function verify($armored, $fingerprint, &$plainText = null)
+    {
+
+
+        $msg = __('The message cannot be verified.');
+        try {
+            $signature = $this->_gpg->verify($armored, false, $plainText);
+            if (empty($signature) || $signature[0]->getKeyFingerprint() !== $fingerprint) {
+                throw new Exception($msg);
+            }
+        } catch (\Exception $e) {
+            throw new Exception($msg);
+        }
+    }
+
+    /**
+     * Sign a text.
+     *
+     * @param string $text plain text to be signed.
+     * @throws Exception if no key was set to sign
+     * @throws Exception if there is an issue with the key to sign
+     * @return string signed text
+     */
+    public function sign(string $text)
+    {
+        $msg = __('Could not sign the text. ');
+        $this->assertSignKey();
+        try {
+            $signedText = $this->_gpg->sign($text);
+            $this->clearSignKeys();
+        } catch (\Exception $e) {
+            $this->clearSignKeys();
+            throw new Exception($msg . $e->getMessage());
+        }
+        if ($signedText === false) {
+            throw new Exception($msg);
+        }
+
+        return $signedText;
+    }
+
+    /**
+     * Removes all keys which were set for decryption before
+     *
+     * @return void
+     */
+    public function clearDecryptKeys()
+    {
+        $this->_decryptKeyFingerprint = null;
+        $this->_gpg->cleardecryptkeys();
+    }
+
+    /**
+     * Removes all keys which were set for signing before
+     *
+     * @return void
+     */
+    public function clearSignKeys()
+    {
+        $this->_signKeyFingerprint = null;
+        $this->_gpg->clearsignkeys();
+    }
+
+    /**
+     * Removes all keys which were set for encryption before
+     *
+     * @return void
+     */
+    public function clearEncryptKeys()
+    {
+        $this->_encryptKeyFingerprint = null;
+        $this->_gpg->clearencryptkeys();
+    }
+}

--- a/src/Utility/OpenPGP/OpenPGPBackendFactory.php
+++ b/src/Utility/OpenPGP/OpenPGPBackendFactory.php
@@ -15,6 +15,7 @@
 namespace App\Utility\OpenPGP;
 
 use App\Utility\OpenPGP\Backends\Gnupg;
+use App\Utility\OpenPGP\Backends\CryptGPG;
 use Cake\Core\Configure;
 use Cake\Core\Exception\Exception;
 use Cake\Http\Exception\InternalErrorException;
@@ -22,6 +23,7 @@ use Cake\Http\Exception\InternalErrorException;
 class OpenPGPBackendFactory
 {
     const GNUPG = 'gnupg';
+    const CRYPT_GPG = 'cryptGPG';
 
     /**
      * @var OpenPGPBackend
@@ -41,6 +43,13 @@ class OpenPGPBackendFactory
             case self::GNUPG:
                 try {
                     return new Gnupg();
+                } catch (Exception $exception) {
+                    throw new InternalErrorException($exception->getMessage());
+                }
+                break;
+            case self::CRYPT_GPG:
+                try {
+                    return new CryptGPG();
                 } catch (Exception $exception) {
                     throw new InternalErrorException($exception->getMessage());
                 }


### PR DESCRIPTION
## Make passbolt work without the php gnupg extension

Many php webhosters don't come with the php gnupg extension but you can relatively easily copy a binary distribution of gpg to them. It would be great if passbolt would support this alternative method of using gpg.

This MR is based on the MR from sknss: https://github.com/passbolt/passbolt_api/pull/260

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did
- Added an extra GPG backend in src/Utility/OpenPGP/Backends that uses the "pear/crypt_gpg" library.
- Added the pear/crypt_gpg library to composer.
