### PR TITLE
Support env variable setting for from address name

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -207,7 +207,7 @@ return [
     'Email' => [
         'default' => [
             'transport' => env('EMAIL_DEFAULT_TRANSPORT', 'default'),
-            'from' => env('EMAIL_DEFAULT_FROM', 'you@localhost'),
+            'from' => [env('EMAIL_DEFAULT_FROM', 'you@localhost') => env('EMAIL_DEFAULT_FROM_NAME', 'Passbolt')],
             //'charset' => 'utf-8',
             //'headerCharset' => 'utf-8',
         ],


### PR DESCRIPTION
Allow users to set the name to used with the "From" email address when Passbolt sends emails.

This pull request is a (multiple allowed):

* [ ] bug fix
* [ ] change of existing behavior
* [x] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [ ] Unit tests are passing
* [ ] Selenium tests are passing
* [ ] Check style is not triggering new error or warning

### What you did

Implement the workaround given in https://community.passbolt.com/t/how-can-i-specify-the-email-senders-name-not-just-from-email/1595/2