### PR TITLE
Force boolean on tls key value

### DIFF
--- a/config/app.default.php
+++ b/config/app.default.php
@@ -241,7 +241,7 @@ return [
             'username' => env('EMAIL_TRANSPORT_DEFAULT_USERNAME', null),
             'password' => env('EMAIL_TRANSPORT_DEFAULT_PASSWORD', null),
             'client' => env('EMAIL_TRANSPORT_DEFAULT_CLIENT', null),
-            'tls' => env('EMAIL_TRANSPORT_DEFAULT_TLS', null),
+            'tls' => filter_var(env('EMAIL_TRANSPORT_DEFAULT_TLS', false), FILTER_VALIDATE_BOOLEAN),
             'url' => env('EMAIL_TRANSPORT_DEFAULT_URL', null),
 
         ],


### PR DESCRIPTION
Cakephp uses this value only as TRUE or FALSE. For whatever reason when the default value is set to 'null' it treats it as TRUE when Docker users either do not pass a variable or are attempting to set it to either NULL or FALSE. It seems to be interpreted as a "non-empty string which is set" instead of boolean (Docker does not handle quotes which suggests it only passes strings to be interpreted https://docs.docker.com/compose/env-file/#syntax-rules). 

https://github.com/passbolt/passbolt_docker/issues/151 shows setting the key value to null will achieve the desired effect, but this eliminates the ability to use an environment variable.

As tested with https://community.passbolt.com/t/unable-to-disable-tls/4084/14 it appears to honor the false value if forced to boolean.

* [x] bug fix