### PR TITLE
Fixed missing slash for user avatar

### DIFF
--- a/templates/email/html/LU/user_setup_complete.php
+++ b/templates/email/html/LU/user_setup_complete.php
@@ -33,7 +33,7 @@ $invitedWhen = $body['invitedWhen'];
 /** @var bool $invitedByYou */
 $invitedByYou = $body['invitedByYou'];
 
-$avatar = 'img/avatar/user.png';
+$avatar = '/img/avatar/user.png';
 
 echo $this->element('Email/module/avatar',[
     'url' => Router::url($avatar, true),


### PR DESCRIPTION
## ISSUE NAME

When sending an email to the users, the avatar cannot be resolved in case it is in a subfolder (app.base is set).

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

### What you did
Grep for 'img/avatar/user.png' revealed that usually a slash is written before. This might be necessary as the subdirectory in the config/passbolt.php file defaults without a slash.
In the long run, there should be a check for it (like: if slash missing -> add slash)

This said, it might make sense to rewrite this PR to something even bigger.