### PR TITLE
Remove duplicate indexes

### DIFF
--- a/config/Migrations/20230109124720_V380DropActionLogsDuplicateIndexes.php
+++ b/config/Migrations/20230109124720_V380DropActionLogsDuplicateIndexes.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class V380DropActionLogsDuplicateIndexes extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * https://book.cakephp.org/phinx/0/en/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+
+        $this->table('action_logs')
+            ->removeIndex([
+                'user_id', 'action_id', 'status'
+            ])
+            ->removeIndex([
+                'action_id',
+            ])
+            ->save();
+    }
+}


### PR DESCRIPTION
## Duplicate indexes in action_logs table

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [x] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did
Recently, I've discovered huge size for the `action_logs` table. This table has the 90% size of all the whole passbolt database. I examined this table and found that it has duplicate indexes. 
Current indexes:
```
  PRIMARY KEY (`id`),
  KEY `id` (`id`),
  KEY `user_id` (`user_id`,`action_id`,`status`),
  KEY `action_id` (`action_id`),
  KEY `status` (`status`),
  KEY `action_id_2` (`action_id`,`status`),
  KEY `user_id_2` (`user_id`,`action_id`,`status`,`created`)
```
They way mysql utilizes indexes , keys `user_id` and `action_id` can be safely removed from the database without affecting search performance. MySQL will use `user_id_2` and `action_id_2` instead. This will greatly reduce the size of the indexes in `action_logs` table .

Some examples:
```
MariaDB [passbolt]> explain select * from action_logs where user_id = XX and action_id = '**' and status = 1 \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: action_logs
         type: ref
possible_keys: user_id,action_id,status,action_id_2,user_id_2
          key: status
      key_len: 4
          ref: const
         rows: 1
        Extra: Using where
```
And with deleted indexes the query is still indexed:
```
MariaDB [passbolt]> explain select * from action_logs where user_id = 1 and action_id = 'xx' and status = '1' \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: action_logs
         type: ref
possible_keys: status,action_id_2,user_id_2
          key: status
      key_len: 4
          ref: const
         rows: 1
        Extra: Using where
```

