### PR TITLE
Add --skip_ssl option to mariadb-dump command to fix issue #575

### DIFF
--- a/src/Command/SqlExportCommand.php
+++ b/src/Command/SqlExportCommand.php
@@ -196,7 +196,7 @@ class SqlExportCommand extends PassboltCommand
     protected function mariaDbDump(array $config, string $dir, string $file): int
     {
         // Build the dump command.
-        $cmd = 'mariadb-dump -h' . escapeshellarg($config['host']) . ' -u' . escapeshellarg($config['username']);
+        $cmd = 'mariadb-dump --skip_ssl -h' . escapeshellarg($config['host']) . ' -u' . escapeshellarg($config['username']);
         if (!empty($config['password'])) {
             $cmd .= ' -p' . escapeshellarg($config['password']);
         }


### PR DESCRIPTION
## Add --skip_ssl option to mariadb-dump command to fix issue #575

This pull request is a (multiple allowed):

* [x] bug fix
* [ ] change of existing behavior
* [ ] new feature

Checklist
* [x] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [x] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did
implemented --skip-ssl to fix the issue [#575](https://github.com/passbolt/passbolt_api/issues/575)
