### PR TITLE
fix(test): migrate ThemesIndexControllerTest to Fixture Factories

### DIFF
--- a/plugins/PassboltCe/AccountSettings/tests/TestCase/Controller/Themes/ThemesIndexControllerTest.php
+++ b/plugins/PassboltCe/AccountSettings/tests/TestCase/Controller/Themes/ThemesIndexControllerTest.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace Passbolt\AccountSettings\Test\TestCase\Controller\Themes;
 
+use App\Test\Factory\UserFactory;
 use App\Test\Lib\AppIntegrationTestCase;
 use Cake\ORM\Locator\LocatorAwareTrait;
 
@@ -32,10 +33,6 @@ class ThemesIndexControllerTest extends AppIntegrationTestCase
      */
     protected $AccountSettings;
 
-    public array $fixtures = [
-        'plugin.Passbolt/AccountSettings.AccountSettings',
-    ];
-
     public function setUp(): void
     {
         parent::setUp();
@@ -44,8 +41,8 @@ class ThemesIndexControllerTest extends AppIntegrationTestCase
 
     public function testThemesIndexSuccess()
     {
-        // Authenticate as ada and list the themes
-        $this->logInAsUser();
+        $user = UserFactory::make()->user()->persist();
+        $this->logInAs($user);
         $this->get('/account/settings/themes.json?api-version=v2');
         $this->assertResponseOk();
     }


### PR DESCRIPTION
## Remove usage of legacy AccountSettings fixture in ThemesIndexControllerTest

This pull request is a (multiple allowed):

* [ ] bug fix
* [x] change of existing behavior
* [ ] new feature

Checklist
* [ ] User stories are present (given, when, then format)
* [x] Unit tests are passing
* [ ] Selenium tests are passing
* [x] Check style is not triggering new error or warning

### What you did

Addresses #536 - Migrate ThemesIndexControllerTest to Fixture Factories.

**Changes:**
- Remove legacy `$fixtures = ['plugin.Passbolt/AccountSettings.AccountSettings']` array
- Add `UserFactory::make()->user()->persist()` for test user creation
- Replace `logInAsUser()` with `logInAs($user)`

This follows the pattern already established in `ThemesSelectControllerTest.php` in the same directory. The test only needs an authenticated user to call the themes index endpoint - it doesn't require pre-existing theme settings.

All 6 theme controller tests pass.