### PR TITLE
Fix GPG nonce UUID validation using incorrect operand

### DIFF
--- a/src/Authenticator/GpgAuthenticator.php
+++ b/src/Authenticator/GpgAuthenticator.php
@@ -461,7 +461,7 @@ class GpgAuthenticator extends SessionAuthenticator
         if ($version != 'gpgauthv1.3.0') {
             return $this->_error($errorMsg . __('wrong version number.'));
         }
-        if ($version != Validation::uuid($uuid)) {
+        if (!Validation::uuid($uuid)) {
             return $this->_error($errorMsg . __('it is not a UUID.'));
         }
         if ($length != 36) {


### PR DESCRIPTION
## Problem

In `GpgAuthenticator::_checkNonce()`, the UUID validation check compares the wrong operand:

```php
// Before — semantically wrong
if ($version != Validation::uuid($uuid)) {
```

`Validation::uuid()` returns a **boolean** (`true`/`false`), not the UUID string. The variable being compared is `$version` — the protocol string `'gpgauthv1.3.0'` — which has nothing to do with UUID validation.

This works today only because PHP loose type coercion happens to produce the correct boolean outcome:
- Valid UUID → `Validation::uuid()` returns `true` → `'gpgauthv1.3.0' != true` → `false` → no error ✓
- Invalid UUID → `Validation::uuid()` returns `false` → `'gpgauthv1.3.0' != false` → `true` → error triggered ✓

However, this is a fragile coincidence. If `Validation::uuid()` ever returns a non-boolean (e.g., the validated string itself), the check would silently stop rejecting invalid UUIDs in the GPG authentication flow.

## Fix

Replace the accidental loose comparison with a direct boolean check on the validation result:

```php
// After — explicit and correct
if (!Validation::uuid($uuid)) {
```

## Impact

- The authentication behaviour is unchanged in the current PHP/CakePHP version
- The fix makes the intent explicit and removes reliance on accidental type coercion
- Prevents a silent security regression if the validation helper's return type changes