### PR TITLE
Escape output file path in SQL dump shell commands

### DIFF
--- a/src/Command/SqlExportCommand.php
+++ b/src/Command/SqlExportCommand.php
@@ -179,7 +179,7 @@ class SqlExportCommand extends PassboltCommand
         if (!empty($config['password'])) {
             $cmd .= ' -p' . escapeshellarg($config['password']);
         }
-        $cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . $dir . $file;
+        $cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . escapeshellarg($dir . $file);
         exec($cmd, $output, $status);
 
         return $status;
@@ -200,7 +200,7 @@ class SqlExportCommand extends PassboltCommand
         if (!empty($config['password'])) {
             $cmd .= ' -p' . escapeshellarg($config['password']);
         }
-        $cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . $dir . $file;
+        $cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . escapeshellarg($dir . $file);
         exec($cmd, $output, $status);
 
         return $status;
@@ -219,7 +219,7 @@ class SqlExportCommand extends PassboltCommand
         // Build the dump command.
         $cmd = 'PGPASSWORD=' . escapeshellarg($config['password']) . ' pg_dump -h ' . escapeshellarg($config['host']);
         $cmd .= ' -U ' . escapeshellarg($config['username']);
-        $cmd .= ' -d ' . escapeshellarg($config['database']) . ' > ' . $dir . $file;
+        $cmd .= ' -d ' . escapeshellarg($config['database']) . ' > ' . escapeshellarg($dir . $file);
         exec($cmd, $output, $status);
 
         return $status;


### PR DESCRIPTION
## Problem

`mysqlDump()`, `mariaDbDump()`, and `postgresDump()` in `SqlExportCommand` all construct a shell command using `exec()`. Every argument passed to the dump utilities is correctly wrapped with `escapeshellarg()` — except the output redirection path:

```php
// Before — $dir and $file are unescaped
$cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . $dir . $file;
```

A path containing shell metacharacters (`;`, `|`, `&&`, backticks) can break out of the redirection context and execute arbitrary shell commands in the context of the web server process.

## Fix

Wrap the concatenated output path with `escapeshellarg()` to match the treatment of all other arguments:

```php
// After
$cmd .= ' ' . escapeshellarg($config['database']) . ' > ' . escapeshellarg($dir . $file);
```

Applied consistently to all three dump methods: `mysqlDump`, `mariaDbDump`, `postgresDump`.

## Impact

- Eliminates the injection surface in the output path across all supported database backends
- No functional change when paths contain only safe characters