### PR TITLE
Do not expose GPG exception details in HTTP 500 responses

### DIFF
--- a/src/Authenticator/GpgAuthenticator.php
+++ b/src/Authenticator/GpgAuthenticator.php
@@ -27,6 +27,7 @@ use Authentication\Authenticator\SessionAuthenticator;
 use Cake\Core\Configure;
 use Cake\Http\Exception\ForbiddenException;
 use Cake\Http\Exception\InternalErrorException;
+use Cake\Log\Log;
 use Cake\Http\Response;
 use Cake\Http\ServerRequest;
 use Cake\ORM\TableRegistry;
@@ -342,9 +343,12 @@ class GpgAuthenticator extends SessionAuthenticator
                 $this->_gpg->importServerKeyInKeyring();
                 $this->_gpg->setDecryptKeyFromFingerprint($fingerprint, $passphrase);
             } catch (Exception $exception) {
-                $msg = __('The OpenPGP server key defined in the config cannot be used to decrypt.') . ' ';
-                $msg .= $exception->getMessage();
-                throw new InternalErrorException($msg, 500, $exception);
+                Log::error('GpgAuthenticator: ' . $exception->getMessage());
+                throw new InternalErrorException(
+                    __('The OpenPGP server key defined in the config cannot be used to decrypt.'),
+                    500,
+                    $exception
+                );
             }
         }
     }


### PR DESCRIPTION
## Problem

`GpgAuthenticator::_initKeyring()` appends the raw GPG library exception message directly into the `InternalErrorException` that propagates as an HTTP 500 response:

```php
// Before
$msg = __('The OpenPGP server key defined in the config cannot be used to decrypt.') . ' ';
$msg .= $exception->getMessage();
throw new InternalErrorException($msg, 500, $exception);
```

GPG library error strings routinely contain internal details that should not reach HTTP clients:
- Absolute file system paths (keyring location, socket paths)
- GPG key IDs and fingerprint fragments
- Passphrase error hints
- GnuPG agent status information

## Fix

Log the exception detail internally using CakePHP's `Log` facade and throw the `InternalErrorException` with only the static, safe message string:

```php
// After
Log::error('GpgAuthenticator: ' . $exception->getMessage());
throw new InternalErrorException(
    __('The OpenPGP server key defined in the config cannot be used to decrypt.'),
    500,
    $exception
);
```

Operators retain full observability through the application log. The original exception is still passed as the third argument to `InternalErrorException` so it remains available in the exception chain for debugging.

## Impact

- HTTP 500 responses no longer include GPG internals
- No change to logging behaviour — detail is preserved at `error` level
- No functional change to authentication flow