### PR TITLE
Replace rand() with random_bytes() for SQL placeholder generation

### DIFF
--- a/src/Model/Traits/Query/CaseSensitiveCompareValueTrait.php
+++ b/src/Model/Traits/Query/CaseSensitiveCompareValueTrait.php
@@ -41,7 +41,7 @@ trait CaseSensitiveCompareValueTrait
             return $col;
         }
 
-        $valuePlaceholder = ':value_case_insensitive_' . rand();
+        $valuePlaceholder = ':value_case_insensitive_' . bin2hex(random_bytes(4));
         $query = $query->bind($valuePlaceholder, $col, $this->getBindType($col));
 
         return $query->newExpr()->add("CONVERT({$valuePlaceholder} using utf8mb4) COLLATE utf8mb4_bin");
@@ -65,7 +65,7 @@ trait CaseSensitiveCompareValueTrait
         $conditions = [];
         $values = array_unique($values);
         foreach ($values as $value) {
-            $valuePlaceholder = ':value_case_insensitive_' . rand();
+            $valuePlaceholder = ':value_case_insensitive_' . bin2hex(random_bytes(4));
             $conditions[] = $query
                 ->newExpr()
                 ->add("CONVERT({$valuePlaceholder} using utf8mb4) COLLATE utf8mb4_bin");


### PR DESCRIPTION
## Problem

`CaseSensitiveCompareValueTrait` uses `rand()` to generate unique named placeholder suffixes when binding values for case-sensitive MySQL/MariaDB comparisons:

```php
// Before
$valuePlaceholder = ':value_case_insensitive_' . rand();
```

`rand()` is a non-cryptographic PRNG. Under concurrent load, or on platforms where the PHP PRNG has low entropy, duplicate values are possible. A collision causes CakePHP's query binder to silently overwrite a previously bound value, producing incorrect query results without raising an error.

## Fix

Replace `rand()` with `bin2hex(random_bytes(4))` which reads from the OS CSPRNG:

```php
// After
$valuePlaceholder = ':value_case_insensitive_' . bin2hex(random_bytes(4));
```

This produces 8 hex characters (32 bits of uniform entropy), giving a collision probability of ~1 in 4 billion per invocation — negligible even under high concurrency.

Applied to both `getCaseSensitiveValue()` and `getCaseSensitiveValues()`.

## Impact

- Eliminates placeholder collision risk under concurrent load
- No functional change under normal conditions
- `random_bytes()` is available in all PHP versions ≥ 7.0