### PR TITLE
Use strict comparisons throughout _checkNonce() validation

### DIFF
--- a/src/Authenticator/GpgAuthenticator.php
+++ b/src/Authenticator/GpgAuthenticator.php
@@ -451,20 +451,20 @@ class GpgAuthenticator extends SessionAuthenticator
 
         $result = explode('|', $nonce);
         $errorMsg = __('Invalid verify token format, ');
-        if (count($result) != 4) {
+        if (count($result) !== 4) {
             return $this->_error($errorMsg . __('sections are missing or using wrong delimiters.'));
         }
         [$version, $length, $uuid, $version2] = $result;
-        if ($version != $version2) {
+        if ($version !== $version2) {
             return $this->_error($errorMsg . __('the version numbers do not match.'));
         }
-        if ($version != 'gpgauthv1.3.0') {
+        if ($version !== 'gpgauthv1.3.0') {
             return $this->_error($errorMsg . __('wrong version number.'));
         }
-        if ($version != Validation::uuid($uuid)) {
+        if (!Validation::uuid($uuid)) {
             return $this->_error($errorMsg . __('it is not a UUID.'));
         }
-        if ($length != 36) {
+        if ($length !== '36') {
             return $this->_error($errorMsg . __('wrong token data length.'));
         }
 


### PR DESCRIPTION
## Problem

`GpgAuthenticator::_checkNonce()` validates the GPG nonce format using loose `!=` comparisons at every check. All values come from `explode('|', $nonce)` and are therefore strings, so loose coercion happens to produce correct results today — but PHP's type juggling rules make this fragile.

The UUID check is additionally wrong at the operand level:

```php
// Comparing $version (the protocol string) against a bool return value
if ($version != Validation::uuid($uuid)) {
```

`Validation::uuid()` returns `true`/`false`. The comparison works only because `'gpgauthv1.3.0' == true` and `'gpgauthv1.3.0' != false` happen to be correct under loose coercion. This is an accident of PHP semantics, not intentional logic.

## Fix

Replace every loose `!=` with strict `!==`, and fix the UUID check to test the validation result directly:

```php
if (count($result) !== 4) { ... }
if ($version !== $version2) { ... }
if ($version !== 'gpgauthv1.3.0') { ... }
if (!Validation::uuid($uuid)) { ... }       // was: $version != Validation::uuid($uuid)
if ($length !== '36') { ... }               // '36' string, since explode() returns strings
```

## Notes

- `$length` is a string from `explode()`, so the strict comparison target changes from integer `36` to string `'36'`. The validation behaviour is identical.
- The UUID check is the most important fix: it removes a logically incorrect comparison that relied on double type coercion to pass.
- No functional change under any PHP version currently in use.