### PR TITLE
Align X-Frame-Options with CSP and add missing X-XSS-Protection header

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -146,7 +146,8 @@ class Application extends BaseApplication implements AuthenticationServiceProvid
             $headers
                 ->setCrossDomainPolicy()
                 ->setReferrerPolicy()
-                ->setXFrameOptions()
+                ->setXFrameOptions('deny')
+                ->setXssProtection()
                 ->noOpen()
                 ->noSniff();
 


### PR DESCRIPTION
## Problem

Two inconsistencies in the `SecurityHeadersMiddleware` configuration in `Application::middleware()`:

### 1. X-Frame-Options too permissive

`setXFrameOptions()` is called without arguments, which defaults to `SAMEORIGIN`. The comment directly above reads **"Don't allow framing the site"**, and `ContentSecurityPolicyMiddleware` already sets `frame-ancestors 'none'` in the default CSP — which prohibits all framing including same-origin.

The `X-Frame-Options` header was weaker than the declared CSP policy, creating an inconsistency:

| Header | Value | Effect |
|---|---|---|
| `Content-Security-Policy` | `frame-ancestors 'none'` | No framing, any origin |
| `X-Frame-Options` (before) | `SAMEORIGIN` | Same-origin framing allowed |

`X-Frame-Options` is the legacy fallback for browsers that don't support CSP `frame-ancestors`. It should match the stricter CSP intent.

### 2. X-XSS-Protection never set

The comment block reads **"Tell browser to block XSS attempts"** but `setXssProtection()` was never called. The `X-XSS-Protection` header was absent from all responses.

## Fix

```php
$headers
    ->setCrossDomainPolicy()
    ->setReferrerPolicy()
    ->setXFrameOptions('deny')   // was: setXFrameOptions() → SAMEORIGIN
    ->setXssProtection()         // was: missing
    ->noOpen()
    ->noSniff();
```

## Impact

- `X-Frame-Options: DENY` now matches the CSP `frame-ancestors 'none'` policy across all browsers including those without CSP support
- `X-XSS-Protection: 1; mode=block` added for legacy browser defence-in-depth
- No impact on modern browsers that enforce CSP