### PR TITLE
Add IP-based rate limiting on failed login attempts

### DIFF
--- a/src/Controller/Auth/AuthLoginController.php
+++ b/src/Controller/Auth/AuthLoginController.php
@@ -22,10 +22,12 @@ use App\Model\Entity\Role;
 use App\Utility\UserAccessControl;
 use App\Utility\UserAction;
 use Authentication\Authenticator\Result;
+use Cake\Cache\Cache;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventInterface;
 use Cake\Event\EventManager;
+use Cake\Http\Exception\HttpException;
 use Cake\Http\Exception\InternalErrorException;
 use Cake\Http\Exception\NotFoundException;
 
@@ -72,18 +74,39 @@ class AuthLoginController extends AppController
     }
 
     /**
+     * Maximum failed login attempts before rate-limiting kicks in.
+     */
+    private const LOGIN_MAX_ATTEMPTS = 10;
+
+    /**
+     * Sliding window duration in seconds for failed attempt tracking.
+     */
+    private const LOGIN_ATTEMPT_WINDOW = 300;
+
+    /**
      * User login post action
      *
      * @return void
+     * @throws \Cake\Http\Exception\HttpException when the client has exceeded the login attempt limit
      */
     public function loginPost()
     {
         $this->assertJson();
 
+        $ip = (string)$this->request->clientIp();
+        $cacheKey = 'auth_fail_' . sha1($ip);
+
+        $attempts = (int)Cache::read($cacheKey);
+        if ($attempts >= self::LOGIN_MAX_ATTEMPTS) {
+            throw new HttpException(__('Too many failed login attempts. Please try again later.'), 429);
+        }
+
         // Custom X-GpgAuth-* http headers are stored in $result->getErrors
         // They are translated into actual http headers as part of GpgAuthHeadersMiddleware::process
         $result = $this->Authentication->getResult();
         if ($result->isValid()) {
+            Cache::delete($cacheKey);
+
             /** @var \App\Authenticator\GpgAuthenticator $authenticator */
             $authenticator = $this->Authentication->getAuthenticationService()->getAuthenticationProvider();
             $user = $authenticator->getUser();
@@ -105,9 +128,11 @@ class AuthLoginController extends AppController
                     $this->error($message, null, 200);
                     break;
                 case Result::FAILURE_IDENTITY_NOT_FOUND:
+                    Cache::write($cacheKey, $attempts + 1, self::LOGIN_ATTEMPT_WINDOW);
                     $this->error($message);
                     break;
                 case Result::FAILURE_CREDENTIALS_INVALID:
+                    Cache::write($cacheKey, $attempts + 1, self::LOGIN_ATTEMPT_WINDOW);
                     $this->error($message);
                     break;
                 case Result::FAILURE_OTHER:


### PR DESCRIPTION
## Problem

The `/auth/login` endpoint had no throttling mechanism. An attacker could issue unlimited POST requests against the GPG authentication endpoint with no server-side consequence, enabling:

- Brute-force enumeration of valid user fingerprints (`FAILURE_IDENTITY_NOT_FOUND` reveals existence)
- Repeated credential replay attempts against known accounts
- Resource exhaustion on the GPG keyring operations

## Implementation

Uses CakePHP's built-in `Cache` to track failed attempts per client IP with a sliding window:

```php
private const LOGIN_MAX_ATTEMPTS = 10;
private const LOGIN_ATTEMPT_WINDOW = 300; // 5 minutes
```

**Flow:**
1. On each `POST /auth/login`, read the attempt counter for the client IP from cache
2. If `>= 10`, return HTTP 429 immediately before any auth processing
3. On `FAILURE_IDENTITY_NOT_FOUND` or `FAILURE_CREDENTIALS_INVALID`, increment the counter (TTL = 300s)
4. On successful authentication, delete the counter for that IP

**Cache key:** `auth_fail_` + `sha1(clientIp)` — normalises IPv6 addresses and prevents cache key injection via crafted IP strings.

## What does NOT increment the counter

`FAILURE_CREDENTIALS_MISSING` (HTTP 200) is the first stage of the GPG two-step handshake and is a normal protocol step, not a failed authentication. It is intentionally excluded from the counter.

## Impact

- Limits each IP to 10 failed attempts per 5-minute window
- No impact on normal usage patterns
- Successful logins are not throttled and clear the failure counter